### PR TITLE
fix(remove): return unchanged list on index >= length

### DIFF
--- a/src/list/remove/remove.test.ts
+++ b/src/list/remove/remove.test.ts
@@ -13,6 +13,9 @@ describe('remove', () => {
       assert.deepEqual(remove(2, 1, [ 1, 2, 3 ]).length, 2)
       assert.deepEqual(remove(0, 1, [ 1, 2, 3, 4 ]), [ 2, 3, 4 ])
       assert.deepEqual(remove(0, 1, [ 1, 2, 3, 4 ]).length, 3)
+      // Fix issue #1
+      assert.deepEqual(remove(3, 1, [ 1, 2, 3 ]), [ 1, 2, 3 ])
+      assert.deepEqual(remove(4, 1, [ 1, 2, 3 ]), [ 1, 2, 3 ])
     })
   })
 })

--- a/src/list/remove/remove.ts
+++ b/src/list/remove/remove.ts
@@ -5,7 +5,7 @@ export const remove: RemoveArity3 = curry3(
   function remove<A>(index: number, amount: number, list: Array<A>): ReadonlyArray<A> {
     const length = list.length
 
-    if (amount === 0 || length === 0)
+    if (amount === 0 || length === 0 || index >= length)
       return list
 
     if (index === 0 && amount >= length)


### PR DESCRIPTION
Add check on `index >= length` to return unchanged list.
See issue #1.

BREAKING CHANGES:

Before:
`remove(3, 1, [ 1, 2, 3 ]) => Range Error`

After:
`remove(3, 1, [ 1, 2, 3 ]) => [ 1, 2, 3 ]`

Closes #1

Signed-off-by: Frederik Krautwald <fkrautwald@gmail.com>

<!--
Thank you for your contribution!
To help speed up the process of merging your code, check the following:
-->

- [x] I added new tests for the issue I fixed or the feature I built
- [x] I ran `yarn test` for the package I'm modifying
- [ ] I used `yarn commit` instead of `git commit`